### PR TITLE
Fix URL to emojilib repository

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
           to the library.
         </p>
         <p>
-          <a class="button js-contribute contribute-button" href="https://github.com/muan/emojilib/edit/gh-pages/emojis.json" target="_blank">Contribute to emojilib</a>
+          <a class="button js-contribute contribute-button" href="https://github.com/muan/emojilib/edit/master/emojis.json" target="_blank">Contribute to emojilib</a>
         </p>
       </div>
     </section>


### PR DESCRIPTION
The `CONTRIBUTE TO EMOJILIB` link refers to the `gh-pages` branch (which does not exist).

<img width="447" alt="screen shot 2015-07-20 at 20 55 19" src="https://cloud.githubusercontent.com/assets/1086961/8784318/a9a045de-2f21-11e5-85a2-aca2970211bd.png">